### PR TITLE
updated test file to be consistent with snappy API

### DIFF
--- a/test/printstat.py
+++ b/test/printstat.py
@@ -4,7 +4,7 @@
 import os
 import sys
 
-sys.path.append("../swig")
+sys.path.insert(0,"../swig")
 
 import snap
 
@@ -17,9 +17,8 @@ if __name__ == '__main__':
     gname = sys.argv[1]
     header = sys.argv[2]
 
-    tname = snap.TStr(gname)
     tlabel = snap.TStr(os.path.splitext(gname)[0])
     theader = snap.TStr(header)
 
-    g = snap.LoadEdgeList(tname, 0, 1)
+    g = snap.LoadEdgeList(snap.PNGraph, gname, 0, 1)
     snap.PrintGraphStatTable(g,tlabel,theader)


### PR DESCRIPTION
One thing which I did which may be objectionable... changed this line:

sys.path.append('../swig')

to:

sys.path.insert(0,'../swig')

the idea being that, if snap.py is already installed in a globally visible location, this will capture the local version which is being built.
