### PR TITLE
add interface for MotifCluster (incomplete)

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -10,6 +10,10 @@ ifeq ($(UNAME), Linux)
   CXXFLAGS += -fPIC -D__STDC_LIMIT_MACROS -DSW_SNAPPY -fopenmp
   LDFLAGS += -shared -fopenmp
   MANIFEST = MANIFEST.nx
+  ifneq (, $(strip $(shell ldconfig -p | grep libarpack)))
+    CXXFLAGS += -DF77_POST
+    LDFLAGS += -larpack
+  endif
 else ifeq ($(UNAME), Darwin)
   # OS X flags
   SWIGFLAGS += -D_CMPWARN -D__stdcall -DSW_SNAPPY -DNONUMPY
@@ -26,6 +30,10 @@ else ifeq ($(UNAME), Darwin)
     CXXOPENMP =
   endif
   MANIFEST = MANIFEST.mac
+  ifneq (, $(strip $(shell ld -larpack 2>&1 | grep symbol)))
+    CXXFLAGS += -DF77_POST
+    LDFLAGS += -larpack
+  endif
 else ifeq ($(shell uname -o), Cygwin)
   # Cygwin flags
   SWIGFLAGS += -D_CMPWARN -D__stdcall -DSW_SNAPPY -DNONUMPY

--- a/swig/Makefile
+++ b/swig/Makefile
@@ -5,7 +5,7 @@
 # Build instructions for Mac OS X and Linux:
 #		make
 #		make dist
-# 
+#
 # Build instructions for Windows:
 #	- run swig in Cygwin to generate snap_wrap.cxx and snap.py
 #		make swig-win
@@ -38,32 +38,21 @@ snap_wrap.cxx: snap.i snap_types.i tvec.i pneanet.i tmodenet.i tcrossnet.i pungr
 snap_wrap.o: snap_wrap.cxx
 	g++ $(CXXFLAGS) -c snap_wrap.cxx -I$(SNAPDIR) -I$(SNAPADVDIR) -I$(GLIBDIR) -I/usr/include/python2.6 -I/usr/include/python2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include
 
-Snap.o: 
+Snap.o:
 	$(CC) $(CXXFLAGS) -c $(SNAPDIR)/Snap.cpp -I$(SNAPDIR) -I$(SNAPADVDIR) -I$(GLIBDIR)
 
-cliques.o: 
-	$(CC) $(CXXFLAGS) -c $(SNAPADVDIR)/cliques.cpp -I$(SNAPDIR) -I$(SNAPADVDIR) -I$(GLIBDIR)
+OBJS = $(addsuffix .o, cliques agm agmfast agmfit biasedrandomwalk motifcluster word2vec n2v)
 
-agm.o: 
-	$(CC) $(CXXFLAGS) -c $(SNAPADVDIR)/agm.cpp -I$(SNAPDIR) -I$(SNAPADVDIR) -I$(GLIBDIR)
+$(OBJS): %.o:
+	$(CC) $(CXXFLAGS) -c $(SNAPADVDIR)/$*.cpp -I$(SNAPDIR) -I$(SNAPADVDIR) -I$(GLIBDIR)
 
-agmfast.o: 
-	$(CC) $(CXXFLAGS) -c $(SNAPADVDIR)/agmfast.cpp -I$(SNAPDIR) -I$(SNAPADVDIR) -I$(GLIBDIR)
-
-agmfit.o: 
-	$(CC) $(CXXFLAGS) -c $(SNAPADVDIR)/agmfit.cpp -I$(SNAPDIR) -I$(SNAPADVDIR) -I$(GLIBDIR)
-
-biasedrandomwalk.o: 
-	$(CC) $(CXXFLAGS) -c $(SNAPADVDIR)/biasedrandomwalk.cpp -I$(SNAPDIR) -I$(SNAPADVDIR) -I$(GLIBDIR)
-
-word2vec.o: 
-	$(CC) $(CXXFLAGS) -c $(SNAPADVDIR)/word2vec.cpp -I$(SNAPDIR) -I$(SNAPADVDIR) -I$(GLIBDIR)
-
-n2v.o: 
-	$(CC) $(CXXFLAGS) -c $(SNAPADVDIR)/n2v.cpp -I$(SNAPDIR) -I$(SNAPADVDIR) -I$(GLIBDIR)
-
-_snap.so: snap_wrap.o Snap.o cliques.o agm.o agmfast.o agmfit.o biasedrandomwalk.o word2vec.o n2v.o
-	g++ $(LDFLAGS) -o _snap.so snap_wrap.o Snap.o cliques.o agm.o agmfast.o agmfit.o biasedrandomwalk.o word2vec.o n2v.o $(LIBS)
+ifeq (, $(findstring -larpack, $(LDFLAGS)))
+_snap.so: $(filter-out motifcluster.o, $(OBJS))
+else
+_snap.so: $(OBJS)
+endif
+_snap.so: snap_wrap.o Snap.o
+	g++ $(LDFLAGS) -o _snap.so $^ $(LIBS)
 
 snap.py: snap_wrap.cxx
 

--- a/swig/snap.i
+++ b/swig/snap.i
@@ -20,8 +20,9 @@ Version = "3.0.2"
 #include "agm.h"
 #include "agmfast.h"
 #include "agmfit.h"
+#include "motifcluster.h"
 #include "n2v.h"
- 
+
 /* #include "Engine.h" */
 #include "snapswig.h"
 
@@ -225,6 +226,7 @@ Version = "3.0.2"
 %include "agm.h"
 %include "agmfast.h"
 %include "agmfit.h"
+%include "motifcluster.h"
 %include "n2v.h"
 
 //%template(Schema) TVec< TPair< TStr, TAttrType> >;


### PR DESCRIPTION
- check if ARPACK installed (so far only on Linux, OSX)
- compile motifcluster.cpp, include motifcluster.h in snap.i
- missing: `typedef WeightVH`

---------------------

To make this fully functional, two things are missing, and I would like to ask for your help:

1. Add `WeightVH`: see below
2. check ARPACK on Windows: I don't have a Windows machine to test on.

I tried adding `WeightVH` in the following way:

**swig/snap.i**
```
%template(WeightVH) TVec<TIntH>;
%ignore TVec< THash<TInt, TInt, TDefaultHashFunc<TInt> > >::GetPrimHashCd;
%ignore TVec< THash<TInt, TInt, TDefaultHashFunc<TInt> > >::GetSecHashCd;
```
**swig/tvec.i**
```
WeightVH.__getitem__ = getitem_vec
WeightVH.__setitem__ = setitem_vec
WeightVH.__iter__ = itervec
WeightVH.__len__ = len_vec
WeightVH.__delitem__ = delitem_vec
```
But both with and without the `%ignore`s, this lead to the compilation error:

**swig/snap_wrap.cxx**
```
error: no member 'GetPrimHashCd' in 'THash<TInt, TInt, TDefaultHashFunc<TInt> >'
error: no member 'GetSecHashCd' in 'THash<TInt, TInt, TDefaultHashFunc<TInt> >'
```
Is it necessary to add functions to the C++ library?