### PR TITLE
Added stream references as per issue #58

### DIFF
--- a/doc/source/reference/attr.rst
+++ b/doc/source/reference/attr.rst
@@ -17,9 +17,9 @@ TAttr
            TAttr(Attrs)
 
    Returns a data structure for tracking sparse attributes, where the keys are integers.
-   If *SIn* is specified, the data structure is loaded from the binary stream. If *Attrs*
-   is specified, the contents of *Attrs* are copied into the new sparse attribute data
-   structure.
+   If *SIn* is specified, the data structure is loaded from the binary stream 
+   (of type :class:`TFIn`). If *Attrs* is specified, the contents of *Attrs* are copied 
+   into the new sparse attribute data structure.
 
    All the attribute related functions return an integer indicating whether there were 
    any errors during execution. Below is a list of functions supported by the 
@@ -27,7 +27,7 @@ TAttr
 
      .. describe:: Save()
 
-        Saves the attributes to a (binary) stream SOut.
+        Saves the attributes to a (binary) stream SOut of type :class:`TFOut`.
 
      .. describe:: Clr()
 
@@ -87,8 +87,8 @@ TAttrPair
            TAttrPair(Attrs)
 
    Returns a data structure for tracking sparse attributes, where the keys are integer pairs.
-   If *SIn* is specified, the data structure is loaded from the binary stream. If *Attrs*
-   is specified, the contents of *Attrs* are copied into the new sparse attribute data
+   If *SIn* is specified, the data structure is loaded from the binary stream (of type :class:`TFIn`). 
+   If *Attrs* is specified, the contents of *Attrs* are copied into the new sparse attribute data
    structure.
 
    All the attribute related functions return an integer indicating whether there were 
@@ -97,7 +97,7 @@ TAttrPair
 
      .. describe:: Save()
 
-        Saves the attributes to a (binary) stream SOut.
+        Saves the attributes to a (binary) stream SOut of type :class:`TFOut`.
 
      .. describe:: Clr()
 

--- a/doc/source/reference/basic.rst
+++ b/doc/source/reference/basic.rst
@@ -16,7 +16,8 @@ TInt
            TInt(SIn)
 
    Returns a new :class:`TInt` initialized with the value specified by optional parameter
-   *val*. If no value is given, the :class:`TInt` object is initialized with the default value 0. If *SIn* is provided, the value is loaded from the binary stream *SIn*.
+   *val*. If no value is given, the :class:`TInt` object is initialized with the default value 0. 
+   If *SIn* is provided, the value is loaded from the binary stream *SIn* (of type :class:`TFIn`).
    In Snap.py, :class:`TInt` is automatically converted to Python type :class:`int`.
 
    Below is a list of functions supported by the :class:`TInt` class:
@@ -24,11 +25,11 @@ TInt
 
      .. describe:: Load(SIn)
 
-        Loads the int from a binary stream *SIn*. 
+        Loads the int from a binary stream *SIn* of type :class:`TFIn`. 
 
      .. describe:: Save(SOut)
 
-        Saves the int to a binary stream *SOut*. 
+        Saves the int to a binary stream *SOut* of type :class:`TFOut`. 
 
      .. describe::  Abs(val)
 
@@ -154,18 +155,19 @@ TFlt
            TFlt(SIn)
 
    Returns a new :class:`TFlt` initialized with the value specified by optional parameter
-   val. If no value is given, the :class:`TFlt` object is initialized with the default value 0. If *SIn* is provided, the value is loaded from the binary stream *SIn*.
+   val. If no value is given, the :class:`TFlt` object is initialized with the default value 0. 
+   If *SIn* is provided, the value is loaded from the binary stream *SIn* (of type :class:`TFIn`).
    In Snap.py, :class:`TFlt` is automatically converted to Python type :class:`float`.
 
    Below is a list of functions supported by the :class:`TFlt` class:
 
      .. describe:: Load(SIn)
 
-        Loads the float from a binary stream *SIn*. 
+        Loads the float from a binary stream *SIn* of type :class:`TFIn`. 
 
      .. describe:: Save(SOut)
 
-        Saves the float to a binary stream *SOut*. 
+        Saves the float to a binary stream *SOut* of type :class:`TFOut`. 
 
      .. describe::  Abs(val)
 
@@ -310,18 +312,19 @@ TStr
            TStr(SIn)
 
    Returns a new :class:`TStr` initialized with the value specified by optional parameter
-   *str*. If no value is given, the :class:`TStr` object is initialized with the empty string. If *SIn* is provided, the value is loaded from the binary stream *SIn*.
+   *str*. If no value is given, the :class:`TStr` object is initialized with the empty string. 
+   If *SIn* is provided, the value is loaded from the binary stream *SIn* (of type :class:`TFIn`).
    In Snap.py, :class:`TStr` is automatically converted to Python type :class:`str`.
 
    Below is a list of functions supported by the :class:`TStr` class:
 
      .. describe:: Load(SIn)
 
-        Loads the string from a binary stream *SIn*. 
+        Loads the string from a binary stream *SIn* of type :class:`TFIn`. 
 
      .. describe:: Save(SOut)
 
-        Saves the string to a binary stream *SOut*. 
+        Saves the string to a binary stream *SOut* of type :class:`TFOut`. 
 
      .. describe:: ChangeCh(orig, repl, start)
 

--- a/doc/source/reference/composite.rst
+++ b/doc/source/reference/composite.rst
@@ -16,7 +16,7 @@ The name :class:`TPair` refers to a general data structure that consists of two 
    
    Creates a :class:`TPair` object consisting of the two values, if provided. If *Val1* and
    *Val2* are not given, the default value for each of their respective types is used.
-   If *SIn* is provided, the pair of values are loaded from the binary stream *SIn*.
+   If *SIn* is provided, the pair of values are loaded from the binary stream *SIn* (of type :class:`TFIn`).
 
    The :class:`TPair` constructor cannot be directly called. To create a :class:`TPair` object, the correct
    constructor must be chosen, which indicates the types of both the values in the pair.
@@ -44,11 +44,11 @@ The name :class:`TPair` refers to a general data structure that consists of two 
 
      .. describe:: Load(SIn)
 
-        Loads the pair from a binary stream *SIn*. 
+        Loads the pair from a binary stream *SIn* of type :class:`TFIn`. 
 
      .. describe:: Save(SOut)
 
-        Saves the pair to a binary stream *SOut*. 
+        Saves the pair to a binary stream *SOut* of type :class:`TFOut`. 
 
      .. describe:: GetMemUsed()
 
@@ -110,7 +110,8 @@ vector. All of the following methods are available for objects that are classifi
    Creates a :class:`TVec` object of size *NumVals*, if specified. It *MxVals* is given, enough
    memory to store *MxVals* will be reserved. MxVals must be larger than *NumVals*. If
    *Vec* - a :class:`TVec` of the same type - is given, the values from *Vec* are copied into the
-   new :class:`TVec`. It *SIn* is provided, the contents of the vector are loaded from the binary stream *SIn*.
+   new :class:`TVec`. 
+   If *SIn* is provided, the contents of the vector are loaded from the binary stream *SIn* of type :class:`TFIn`.
 
    The :class:`TVec` constructor cannot be directly called. To create a :class:`TVec` object, the correct
    constructor must be chosen, which indicates the type stored in the :class:`TVec`.
@@ -175,11 +176,11 @@ vector. All of the following methods are available for objects that are classifi
 
      .. describe:: Load(SIn)
 
-        Loads a graph from a binary stream *SIn* and returns a pointer to it. 
+        Loads a graph from a binary stream *SIn* (of type :class:`TFIn`) and returns a pointer to it. 
 
      .. describe:: Save(SOut)
 
-        Saves the graph to a binary stream *SOut*. 
+        Saves the graph to a binary stream *SOut* of type :class:`TFOut`. 
 
      .. describe:: GetMemUsed()
 
@@ -499,7 +500,8 @@ Hash tables contain values of the same type. Each value has a user provided key 
    
    Creates a :class:`THash` object with a capacity of *ExpectVals*, if specified.  If *Hash* - a
    :class:`THash` of the same type - is given, the values from *Hash* are copied into the
-   new :class:`THash`. If *SIn* is provided, the contents of the hash table are loaded from the binary stream *SIn*.
+   new :class:`THash`. 
+   If *SIn* is provided, the contents of the hash table are loaded from the binary stream *SIn* of type :class:`TFIn`.
 
    The :class:`THash` constructor cannot be directly called. To create a :class:`THash` object, the correct
    constructor must be chosen, which indicates the types of the key and value in the :class:`THash`. Hash table types in Snap.py and SNAP use a naming convention of being named
@@ -554,11 +556,11 @@ Hash tables contain values of the same type. Each value has a user provided key 
 
      .. describe:: Load(SIn)
 
-        Loads the hash table from a binary stream *SIn*. 
+        Loads the hash table from a binary stream *SIn* of type :class:`TFIn`. 
 
      .. describe:: Save(SOut)
 
-        Saves the hash table to a binary stream *SOut*. 
+        Saves the hash table to a binary stream *SOut* of type :class:`TFOut`. 
 
      .. describe:: GetMemUsed()
 
@@ -745,7 +747,7 @@ Object used to represent the key-value pairs in a :class:`THash` object.
            TKeyDat(SIn)
 
 
-   Creates a :class:`TKeyDat` object. If *KeyDat* is provided, which is of type :class:`TKeyDat`, its contents will be copied into the newly created object. If *Key* and/or *Dat* are provided, the key for :class:`TKeyDat` will be set to *Key* and the value will be set to *Dat*. If *SIn* is provided, the contents of the :class:`TKeyDat` will be read from the stream.
+   Creates a :class:`TKeyDat` object. If *KeyDat* is provided, which is of type :class:`TKeyDat`, its contents will be copied into the newly created object. If *Key* and/or *Dat* are provided, the key for :class:`TKeyDat` will be set to *Key* and the value will be set to *Dat*. If *SIn* is provided, the contents of the :class:`TKeyDat` will be read from the stream of type :class:`TFIn`.
 
 
    The :class:`TKeyDat` constructor cannot be directly called. To create a :class:`TKeyDat` object, the correct
@@ -761,7 +763,7 @@ Object used to represent the key-value pairs in a :class:`THash` object.
 
      .. describe:: Save(SOut)
 
-        Saves the contents to the binary stream *SOut*
+        Saves the contents to the binary stream *SOut* of type :class:`TFOut`.
 
      .. describe:: GetPrimHashCd()
 
@@ -853,7 +855,9 @@ Hash sets contain keys are of the same type. Specific keys can be accessed throu
            THashSet(SIn)
 
    
-   Creates a :class:`THashSet` object with a capacity of *ExpectVals*, if specified.  If *KeyV* is provided, which should hold the same type of object the hash set holds, a hash set with the unique values in the vector is created. If *SIn* is provided, the contents of the hash set are loaded from the binary stream *SIn*.
+   Creates a :class:`THashSet` object with a capacity of *ExpectVals*, if specified.  
+   If *KeyV* is provided, which should hold the same type of object the hash set holds, a hash set with the unique values in the vector is created. 
+   If *SIn* is provided, the contents of the hash set are loaded from the binary stream *SIn* of type :class:`TFIn`.
 
    The :class:`THashSet` constructor cannot be directly called. To create a :class:`THashSet` object, the correct constructor must be chosen, which indicates the type of the key in the hash set. Hash set types in Snap.py and SNAP use a naming convention of being named
    as `<key_type_name>`, followed by `Set`. For example, a hash set 
@@ -912,11 +916,11 @@ Hash sets contain keys are of the same type. Specific keys can be accessed throu
 
      .. describe:: Load(SIn)
 
-        Loads the hash set from a binary stream *SIn*. 
+        Loads the hash set from a binary stream *SIn* of type :class:`TFIn`. 
 
      .. describe:: Save(SOut)
 
-        Saves the hash set to a binary stream *SOut*. 
+        Saves the hash set to a binary stream *SOut* of type :class:`TFOut`. 
 
      .. describe:: GetMemUsed()
 

--- a/doc/source/reference/graphs.rst
+++ b/doc/source/reference/graphs.rst
@@ -42,11 +42,11 @@ TUNGraph
 
      .. describe:: Load(SIn)
 
-        Loads a graph from a binary stream *SIn* and returns a pointer to it. 
+        Loads a graph from a binary stream *SIn* (of type :class:`TFIn`) and returns a pointer to it. 
 
      .. describe:: Save(SOut)
 
-        Saves the graph to a binary stream *SOut*. 
+        Saves the graph to a binary stream *SOut* (of type :class:`TFOut`). 
 
      .. describe:: Nodes()
 
@@ -335,11 +335,11 @@ TNGraph
 
      .. describe:: Load(SIn)
 
-        Loads a graph from a binary stream *SIn* and returns a pointer to it. 
+        Loads a graph from a binary stream *SIn* (of type :class:`TFIn`) and returns a pointer to it. 
 
      .. describe:: Save(SOut)
 
-        Saves the graph to a binary stream *SOut*. 
+        Saves the graph to a binary stream *SOut* of type :class:`TFOut`. 
 
      .. describe:: Nodes()
 
@@ -634,11 +634,11 @@ TNEANet
 
      .. describe:: Load(SIn)
 
-        Loads a graph from a binary stream *SIn* and returns a pointer to it. 
+        Loads a graph from a binary stream *SIn* (of type :class:`TFIn`) and returns a pointer to it. 
 
      .. describe:: Save(SOut)
 
-        Saves the graph to a binary stream *SOut*. 
+        Saves the graph to a binary stream *SOut* of type :class:`TFOut`. 
 
      .. describe:: Nodes()
 
@@ -1347,11 +1347,11 @@ TUndirNet
 
      .. describe:: Load(SIn)
 
-        Loads a graph from a binary stream *SIn* and returns a pointer to it. 
+        Loads a graph from a binary stream *SIn* (of type :class:`TFIn`) and returns a pointer to it. 
 
      .. describe:: Save(SOut)
 
-        Saves the graph to a binary stream *SOut*. 
+        Saves the graph to a binary stream *SOut* of type :class:`TFOut`. 
 
      .. describe:: GetNodes()
 
@@ -1712,11 +1712,11 @@ TDirNet
 
      .. describe:: Load(SIn)
 
-        Loads a graph from a binary stream *SIn* and returns a pointer to it. 
+        Loads a graph from a binary stream *SIn* (of type :class:`TFIn`) and returns a pointer to it. 
 
      .. describe:: Save(SOut)
 
-        Saves the graph to a binary stream *SOut*. 
+        Saves the graph to a binary stream *SOut* of type :class:`TFOut`. 
 
      .. describe:: GetNodes()
 

--- a/doc/source/reference/multimodal.rst
+++ b/doc/source/reference/multimodal.rst
@@ -228,7 +228,7 @@ TCrossNet
 
      .. describe:: Save(SOut)
 
-        Saves the crossnet to a binary stream *SOut*. 
+        Saves the crossnet to a binary stream *SOut* of type :class:`TFOut`. 
 
      .. describe:: GetEdges()
 
@@ -463,11 +463,11 @@ TMMNet
 
      .. describe:: Load(SIn)
 
-        Loads the multimodal network from a binary stream *SIn* and returns a pointer to it. 
+        Loads the multimodal network from a binary stream *SIn* (of type :class:`TFIn`) and returns a pointer to it. 
 
      .. describe:: Save(SOut)
 
-        Saves the multimodal network to a binary stream *SOut*. 
+        Saves the multimodal network to a binary stream *SOut* of type :class:`TFOut`. 
 
      .. describe:: GetModeNets()
 

--- a/doc/source/reference/table.rst
+++ b/doc/source/reference/table.rst
@@ -113,7 +113,7 @@ TTable
 
    Returns a new table. If no parameters are provided, an empty table is returned. If
    *S* and *Context* are provided, the table is initialized with the provided Schema and
-   TTableContext. If *SIn* is provided, the table is read from the binary stream. If *H*, a
+   TTableContext. If *SIn* is provided, the table is read from the binary stream (of type :class:`TFIn`). If *H*, a
    :class:`THash` with :class:`TInt` keys and either :class:`TInt` or :class:`TFlt` values,
    is given, the TTable is constructed from the hash table. If *IsStrKeys* is True, then 
    the :class:`TInt` keys in *H* refer to strings in the *Context*. *Col1* provides the name
@@ -454,7 +454,7 @@ TTable
 
       .. describe:: Load(SIn, Context)
 
-         Loads table from the input stream *SIn* using
+         Loads table from the input stream *SIn* (of type :class:`TFIn`) using
          :class:`TTableContext` *Context*. Returns a :class:`PTable`.
 
       .. describe:: LoadSS(Schema, InFNm, Context, Separator='\\t', HasTitleLine=False)


### PR DESCRIPTION
https://github.com/snap-stanford/snap-python/issues/58 had trouble finding the stream classes (as binary streams are just called file streams in snap documentation, and there was confusion between TFOut/TSOut), so directed all mentions of binary streams to the correct class reference.