### PR TITLE
WIP: refactor setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include snap/__init__.py

--- a/Makefile.config
+++ b/Makefile.config
@@ -8,10 +8,10 @@ ifeq ($(UNAME), Linux)
   # Linux flags
   SWIGFLAGS += -D_CMPWARN -D__stdcall -DSW_SNAPPY -D_OPENMP -DNONUMPY -DUSE_OPENMP -DGCC_ATOMIC
   CXXFLAGS += -fPIC -D__STDC_LIMIT_MACROS -DSW_SNAPPY -fopenmp
-  IFLAGS = -I/usr/include/python2.6 -I/usr/include/python2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include
-  IFLAGS3 = -I/usr/local/include/python3.7m  -I/usr/include/python3.7m
-  IFLAGS3 += -I/usr/local/include/python3.6m  -I/usr/include/python3.6m
-  IFLAGS3 += -I/usr/local/include/python3.5m  -I/usr/include/python3.5m
+  IFLAGS ?= -I/usr/include/python2.6 -I/usr/include/python2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include
+  IFLAGS3 ?= -I/usr/local/include/python3.7m  -I/usr/include/python3.7m \
+           -I/usr/local/include/python3.6m  -I/usr/include/python3.6m \
+           -I/usr/local/include/python3.5m  -I/usr/include/python3.5m
   LDFLAGS += -shared -fopenmp
   LDFLAGS3 += -shared -fopenmp
   MANIFEST = MANIFEST.nx
@@ -26,11 +26,10 @@ else ifeq ($(UNAME), Darwin)
   CC = g++
   SWIGFLAGS += -D_CMPWARN -D__stdcall -DSW_SNAPPY -DNONUMPY
   CXXFLAGS += -DSW_SNAPPY
-  IFLAGS = -I/usr/include/python2.6 -I/usr/include/python2.7 -I/usr/lib/python2.7/dist-packages/numpy/core/include -I/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7 -I/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/numpy/core/include -I/usr/local/opt/python2/Frameworks/Python.framework/Versions/2.7/Headers -I/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7
-  IFLAGS3 = -I/usr/local/include/python3.6m  -I/usr/include/python3.6m -I/usr/local/Frameworks/Python.framework/Versions/3.7/include/python3.7m -I/usr/local/Frameworks/Python.framework/Versions/3.7/Headers
-  LDFLAGS += -lpython -dynamiclib -headerpad_max_install_names
-  LDFLAGS3 += -L/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib
-  LDFLAGS3 += -lpython3.7 -dynamiclib -headerpad_max_install_names
+  IFLAGS := $(shell python-config --includes)
+  IFLAGS3 := $(shell python3-config --includes)
+  LDFLAGS := $(shell python-config --ldflags) -dynamiclib -headerpad_max_install_names
+  LDFLAGS3 := $(shell python3-config --ldflags) -dynamiclib -headerpad_max_install_names
   CLANG := $(shell g++ -v 2>&1 | grep clang | cut -d " " -f 2)
   ifeq ($(CLANG), LLVM)
     CXXFLAGS += -DNOMP

--- a/dev/swig-r/Makefile
+++ b/dev/swig-r/Makefile
@@ -1,14 +1,14 @@
 #
 # Makefile for SWIG processing of SNAP
-# 
+#
 
 # set the path to your SNAP directory here
-GITDIR = ../../../snap
+SNAPROOT = ../../../snap
 
-include $(GITDIR)/Makefile.config
+include $(SNAPROOT)/Makefile.config
 
-SNAPDIR = $(GITDIR)/$(SNAP)
-GLIBDIR = $(GITDIR)/$(GLIB)
+SNAPDIR = $(SNAPROOT)/$(SNAP)
+GLIBDIR = $(SNAPROOT)/$(GLIB)
 
 RINGODIR = ../../ringo/ringo-engine
 
@@ -41,8 +41,7 @@ python: Snap.o Engine.o jusnap.i
 #  rm -f libengine.a
 #  ar -cvq libengine.a Engine.o
 
-Snap.o: 
+Snap.o:
 	$(CC) $(CXXFLAGS) -c $(SNAPDIR)/Snap.cpp -I$(SNAPDIR) -I$(GLIBDIR)
 clean:
 	rm -f *.o *_wrap.cxx _*.so *.pyc
-

--- a/dev/swig-sw/Makefile
+++ b/dev/swig-sw/Makefile
@@ -1,14 +1,14 @@
 #
 # Makefile for SWIG processing of SNAP
-# 
+#
 
 # set the path to your SNAP directory here
-GITDIR = ../../../snap
+SNAPROOT = ../../../snap
 
-include $(GITDIR)/Makefile.config
+include $(SNAPROOT)/Makefile.config
 
-SNAPDIR = $(GITDIR)/$(SNAP)
-GLIBDIR = $(GITDIR)/$(GLIB)
+SNAPDIR = $(SNAPROOT)/$(SNAP)
+GLIBDIR = $(SNAPROOT)/$(GLIB)
 
 UNAME := $(shell uname)
 
@@ -36,8 +36,7 @@ python: Snap.o snap.i
 	g++ $(CXXFLAGS) $(SWIGFLAGS) -c snap_wrap.cxx $(SWIGFILES) -I$(SNAPDIR) -I$(GLIBDIR) -I/usr/include/python2.6 -I/usr/include/python2.7
 	g++ $(LDFLAGS) $(CXXFLAGS) snap_wrap.o Snap.o -o _snap.so
 
-Snap.o: 
+Snap.o:
 	$(CC) $(CXXFLAGS) $(SWIGFLAGS) -c $(SNAPDIR)/Snap.cpp -I$(SNAPDIR) -I$(GLIBDIR)
 clean:
 	rm -f *.o *_wrap.cxx _*.so *.pyc
-

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,59 @@
+"""
+setup.py file for SNAP (Stanford Network Analysis Platform) Python
+    Linux version, generated on CentOS, tested on Ubuntu as well
+"""
+import os
+import shutil
+import subprocess
+
+from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
+
+
+SNAPPY_VERSION = "5.1.0.dev0"
+
+
+class SwigExtension(Extension):
+    def __init__(self, name, sourcedir=''):
+        Extension.__init__(self, name, sources=[])
+        self.sourcedir = os.path.abspath(sourcedir)
+
+
+class SwigBuild(build_ext):
+    def run(self):
+        for ext in self.extensions:
+            self.build_extension(ext)
+
+    def build_extension(self, ext):
+        extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+
+        subprocess.check_call(['make'])
+
+        if not os.path.exists(extdir):
+            os.makedirs(extdir)
+
+        shutil.copy('swig/_snap.so', extdir)
+        shutil.copy('swig/snap.py', extdir)
+
+
+with open('README.md') as f:
+    LONG_DESCRIPTION = f.read()
+
+setup(
+    name='snap-stanford',
+    version=SNAPPY_VERSION,
+    author="snap.stanford.edu",
+    description="SNAP (Stanford Network Analysis Platform) Python",
+    long_description=LONG_DESCRIPTION,
+    url="http://snap.stanford.edu",
+    classifiers=[
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
+        "Operating System :: MacOS",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: POSIX :: Linux"
+    ],
+    zip_safe=False,
+    cmdclass=dict(build_ext=SwigBuild),
+    ext_modules=[SwigExtension('snap._snap2')],
+)

--- a/setup/Makefile
+++ b/setup/Makefile
@@ -1,29 +1,29 @@
 #
 # Makefile for compilation of SNAP Python from SWIG output
-# 
+#
 
 SNAPVER = 2.x
 
 # set the path to your SNAP directory here
-#GITDIR = ../Snap-$(SNAPVER)
-GITDIR = ../../snap
-SNAPDIR = $(GITDIR)/$(SNAP)
-GLIBDIR = $(GITDIR)/$(GLIB)
+#SNAPROOT = ../Snap-$(SNAPVER)
+SNAPROOT = ../../snap
+SNAPDIR = $(SNAPROOT)/$(SNAP)
+GLIBDIR = $(SNAPROOT)/$(GLIB)
 
 SWIGDIR = ../swig
 
 # include compilation parameters
-include $(GITDIR)/Makefile.config
+include $(SNAPROOT)/Makefile.config
 include ../Makefile.config
 
 all: _snap.so
 
 snap_wrap.o: snap_wrap.cxx
-	@if [ -r Version ] &&  ! diff Version $(GITDIR)/Version >/dev/null ; then echo "*** Error: SNAP versions do not match"; exit 1; fi
+	@if [ -r Version ] &&  ! diff Version $(SNAPROOT)/Version >/dev/null ; then echo "*** Error: SNAP versions do not match"; exit 1; fi
 	g++ $(CXXFLAGS) -c snap_wrap.cxx -I$(SWIGDIR) -I$(SNAPDIR) -I$(GLIBDIR)  -I/usr/include/python2.6 -I/usr/include/python2.7
 
-Snap.o: 
-	@if [ -r Version ] &&  ! diff Version $(GITDIR)/Version >/dev/null ; then echo "*** Error: SNAP versions do not match"; exit 1; fi
+Snap.o:
+	@if [ -r Version ] &&  ! diff Version $(SNAPROOT)/Version >/dev/null ; then echo "*** Error: SNAP versions do not match"; exit 1; fi
 	$(CC) $(CXXFLAGS) -c $(SNAPDIR)/Snap.cpp -I$(SNAPDIR) -I$(GLIBDIR)
 
 _snap.so: snap_wrap.o Snap.o
@@ -39,8 +39,7 @@ dist: setup.py snap.py _snap.so
 
 build:
 	swig -python -c++ -w302,312,317,325,362,383,384,389,401,503,508,509 -O -D_CMPWARN -outcurrentdir -I$(SWIGDIR) -I$(SNAPDIR) -I$(GLIBDIR) $(SWIGDIR)/snap.i
-	cp $(GITDIR)/Version .
+	cp $(SNAPROOT)/Version .
 
 clean:
 	rm -f *.o _*.so *.pyc
-

--- a/snap/__init__.py
+++ b/snap/__init__.py
@@ -1,0 +1,1 @@
+from snap.snap import *

--- a/swig/MANIFEST.in.nx
+++ b/swig/MANIFEST.in.nx
@@ -1,0 +1,2 @@
+include _snap.so
+

--- a/swig/Makefile
+++ b/swig/Makefile
@@ -23,7 +23,7 @@
 # NOTE: python3 build on macOS
 #	- use brew python for all the steps
 #	- the final packages requires brew
-# 
+#
 # Build instructions for py2 on Windows:
 #	- run swig in Cygwin to generate snap_wrap.cxx and snap.py
 #		make swig-win
@@ -70,16 +70,14 @@
 #				      # EXECUTE MANUALLY FROM COMMAND PROMPT
 
 # set the path to your SNAP directory here
-GITDIR = ../../snap
-SNAPDIR = $(GITDIR)/$(SNAP)
-GLIBDIR = $(GITDIR)/$(GLIB)
-SNAPADVDIR = $(GITDIR)/$(SNAPADV)
-SNAPEXPDIR = $(GITDIR)/$(SNAPEXP)
-
-WHLFILE := $(shell ls -rt dist/*.whl | tail -1)
+SNAPROOT ?= ../../snap
+SNAPDIR = $(SNAPROOT)/$(SNAP)
+GLIBDIR = $(SNAPROOT)/$(GLIB)
+SNAPADVDIR = $(SNAPROOT)/$(SNAPADV)
+SNAPEXPDIR = $(SNAPROOT)/$(SNAPEXP)
 
 # include compilation parameters
-include $(GITDIR)/Makefile.config
+include $(SNAPROOT)/Makefile.config
 include ../Makefile.config
 
 all: all3
@@ -95,7 +93,7 @@ snap3.py: snap_wrap3.cxx
 _snap.so: snap_wrap.o Snap.o cliques.o agm.o agmfast.o agmfit.o biasedrandomwalk.o word2vec.o n2v.o
 	$(CC) $(LDFLAGS) $(LIBS) snap_wrap.o Snap.o cliques.o agm.o agmfast.o agmfit.o biasedrandomwalk.o word2vec.o n2v.o -o _snap.so
 
-_snap3.so: snap_wrap3.o Snap.o 
+_snap3.so: snap_wrap3.o Snap.o
 	$(CC) $(LDFLAGS3) $(LIBS) snap_wrap3.o Snap.o -o _snap.so
 	ln -f _snap.so _snap3.so
 
@@ -115,28 +113,28 @@ snap_wrap3.o: snap_wrap3.cxx
 	$(CC) $(CXXFLAGS) -I$(SNAPDIR) -I$(GLIBDIR) $(IFLAGS3) -c snap_wrap3.cxx -o snap_wrap.o
 	ln -f snap_wrap.o snap_wrap3.o
 
-Snap.o: 
+Snap.o:
 	$(CC) $(CXXFLAGS) -I$(SNAPDIR) -I$(GLIBDIR) -c $(SNAPDIR)/Snap.cpp
 
-cliques.o: 
+cliques.o:
 	$(CC) $(CXXFLAGS) -I$(SNAPDIR) -I$(SNAPADVDIR) -I$(GLIBDIR) -c $(SNAPADVDIR)/cliques.cpp
 
-agm.o: 
+agm.o:
 	$(CC) $(CXXFLAGS) -I$(SNAPDIR) -I$(SNAPADVDIR) -I$(GLIBDIR) -c $(SNAPADVDIR)/agm.cpp
 
-agmfast.o: 
+agmfast.o:
 	$(CC) $(CXXFLAGS) -I$(SNAPDIR) -I$(SNAPADVDIR) -I$(GLIBDIR) -c $(SNAPADVDIR)/agmfast.cpp
 
-agmfit.o: 
+agmfit.o:
 	$(CC) $(CXXFLAGS) -I$(SNAPDIR) -I$(SNAPADVDIR) -I$(GLIBDIR) -c $(SNAPADVDIR)/agmfit.cpp
 
-biasedrandomwalk.o: 
+biasedrandomwalk.o:
 	$(CC) $(CXXFLAGS) -I$(SNAPDIR) -I$(SNAPADVDIR) -I$(GLIBDIR) -c $(SNAPADVDIR)/biasedrandomwalk.cpp
 
-word2vec.o: 
+word2vec.o:
 	$(CC) $(CXXFLAGS) -I$(SNAPDIR) -I$(SNAPADVDIR) -I$(GLIBDIR) -c $(SNAPADVDIR)/word2vec.cpp
 
-n2v.o: 
+n2v.o:
 	$(CC) $(CXXFLAGS) -I$(SNAPDIR) -I$(SNAPADVDIR) -I$(GLIBDIR) -c $(SNAPADVDIR)/n2v.cpp
 
 install: setup.py snap.py _snap.so
@@ -217,4 +215,3 @@ pip-public: dist/*
 pip3-public: dist/*
 	@echo PUBLIC RELEASE uploading file ${WHLFILE}
 	"$(PYTHON3)" -m twine upload ${WHLFILE}
-


### PR DESCRIPTION
So that:
- one can `pip install .` from the root dir.
- _snap.so and snap.py live in a folder.

This will solve the following diagnostic issue:
```
$ auditwheel show ~/Downloads/snap_stanford-5.0.0-cp36-cp36m-manylinux1_x86_64.whl                                                      

Traceback (most recent call last):
  File "/home/bcoste/.virtualenvs/vasc/bin/auditwheel", line 8, in <module>
    sys.exit(main())
  File "/home/bcoste/.virtualenvs/vasc/lib/python3.6/site-packages/auditwheel/main.py", line 50, in main
    rval = args.func(args, p)
  File "/home/bcoste/.virtualenvs/vasc/lib/python3.6/site-packages/auditwheel/main_show.py", line 37, in execute
    winfo = analyze_wheel_abi(args.WHEEL_FILE)
  File "/home/bcoste/.virtualenvs/vasc/lib/python3.6/site-packages/auditwheel/wheel_abi.py", line 204, in analyze_wheel_abi
    uses_PyFPE_jbuf) = get_wheel_elfdata(wheel_fn)
  File "/home/bcoste/.virtualenvs/vasc/lib/python3.6/site-packages/auditwheel/wheel_abi.py", line 104, in get_wheel_elfdata
    ) % '\n\t'.join(shared_libraries_in_purelib)
RuntimeError: Invalid binary wheel, found the following shared library/libraries in purelib folder:
	_snap.so
```
Which is one of the reason why the wheel is not manylinux compatible.